### PR TITLE
CMS automatically duplicates linking to related posts

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -343,7 +343,9 @@ class Post(models.Model):
             'If checked this post will be displayed in the category\'s '
             'list of featured posts on the homepage.'))
 
-    related_posts = SortedManyToManyField('self', blank=True)
+    related_posts = SortedManyToManyField(
+        'self', blank=True, symmetrical=False,
+        related_name='related_posts_set')
 
     localisation = models.ForeignKey(
         Localisation, blank=True, null=True)

--- a/cms/tests/test_models.py
+++ b/cms/tests/test_models.py
@@ -7,7 +7,8 @@ from django.test.utils import override_settings
 
 from cms.tests.base import BaseCmsTestCase
 from cms.models import (
-    ContentRepository, PublishingTarget, CUSTOM_REPO_LICENSE_TYPE)
+    ContentRepository, PublishingTarget, CUSTOM_REPO_LICENSE_TYPE,
+    Post)
 from cms.admin import ContentRepositoryAdmin
 
 
@@ -79,6 +80,14 @@ class TestContentRepository(BaseCmsTestCase):
         self.assertEqual(PublishingTarget.objects.count(), 1)
         [target] = obj.targets.all()
         self.assertEqual(target.name, 'The Target')
+
+    def test_linked_pages_asymmetry(self):
+        post1 = Post.objects.create(title='post 1')
+        post2 = Post.objects.create(title='post 2')
+        post2.related_posts.add(post1)
+        post2.save()
+        self.assertEqual(post2.related_posts.count(), 1)
+        self.assertEqual(post1.related_posts.count(), 0)
 
 
 class TestPublishingTarget(BaseCmsTestCase):


### PR DESCRIPTION
Issue raised by Sarah:
"If I link article A to article B the system automatically links B back to A as well.
So any post that I linked to 'Your New Baby' will then also have a link from 'Your New Baby' to it. This is not ideal as I linked many posts to this particular post (for example) but don't want to link from this post to all those articles. "

This was originally filed under https://github.com/praekelt/unicore-cms/issues/42
