### PR TITLE
If a filter query is specified in the URL the translate button doesn't work. 

### DIFF
--- a/project/templates/admin/cms/category/change_form.html
+++ b/project/templates/admin/cms/category/change_form.html
@@ -13,7 +13,11 @@
     {{ block.super }}
     {% if has_add_permission %}
         {% url 'admin:cms_category_add' as add_url %}
-        <li><a href="{% add_preserved_filters add_url %}?source={{object_id}}" class="addlink">{% trans "Translate" %}</a></li>
+        {% if opts and preserved_filters %}
+            <li><a href="{% add_preserved_filters add_url %}&amp;source={{object_id}}" class="addlink">{% trans "Translate" %}</a></li>
+        {% else %}
+            <li><a href="{{ add_url }}?source={{object_id}}" class="addlink">{% trans "Translate" %}</a></li>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/project/templates/admin/cms/post/change_form.html
+++ b/project/templates/admin/cms/post/change_form.html
@@ -13,7 +13,11 @@
     {{ block.super }}
     {% if has_add_permission %}
         {% url 'admin:cms_post_add' as add_url %}
-        <li><a href="{% add_preserved_filters add_url %}?source={{object_id}}" class="addlink">{% trans "Translate" %}</a></li>
+        {% if opts and preserved_filters %}
+            <li><a href="{% add_preserved_filters add_url %}&amp;source={{object_id}}" class="addlink">{% trans "Translate" %}</a></li>
+        {% else %}
+            <li><a href="{{ add_url }}?source={{object_id}}" class="addlink">{% trans "Translate" %}</a></li>
+        {% endif %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
This is because we're always appending `?source=foo`. When there are already query parameters in the URL we should add `&source=foo` instead.

![screenshot_2015_01_06__12_30_pm](https://cloud.githubusercontent.com/assets/1065/5627377/e352cd18-959f-11e4-8b87-5236e0e6106f.jpg)

Django's [`admin_urls` template tag](https://github.com/django/django/blob/stable/1.6.x/django/contrib/admin/templatetags/admin_urls.py#L21-L23) defines the `add_preserved_filters` tag and that checks the template variable context for the existence of `opts` and `preserved_filters` and if they exist, appends the vars. We need to do the same here unfortunately.
